### PR TITLE
Make uniq preserve order, like underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "fs-promise": "0.5.0",
     "mocha": "2.4.5",
     "mustache": "2.2.1",
-    "uglify-js": "2.6.2"
+    "uglify-js": "2.6.2",
+    "underscore": "1.8.3"
   }
 }

--- a/test/itBehaves.js
+++ b/test/itBehaves.js
@@ -1,0 +1,19 @@
+var underscore = require('underscore');
+var lowscore = require('..');
+var expect = require('chai').expect;
+
+module.exports = {
+  likeUnderscoreFor: function(expression) {
+    it('beahves like underscore for ' + expression, function() {
+      var underscoreValue = evaluateAgainst(underscore, expression);
+      var lowscoreValue = evaluateAgainst(lowscore, expression);
+      expect(lowscoreValue).to.eql(underscoreValue);
+    });
+  }
+}
+
+function evaluateAgainst(library, expression) {
+  var _ = library;
+  eval('var result = ' + expression);
+  return result;
+}

--- a/test/uniqSpec.js
+++ b/test/uniqSpec.js
@@ -1,6 +1,7 @@
 var uniq = require('../uniq');
 var expect = require('chai').expect;
 var times = require('../times');
+var itBehaves = require('./itBehaves');
 
 describe('uniq', function () {
   it('removes duplicate entries', function () {
@@ -12,4 +13,6 @@ describe('uniq', function () {
 
     expect(uniq(array)).to.eql([a, b, c]);
   });
+  
+  itBehaves.likeUnderscoreFor('_.uniq([1,2,3,2,3])');
 });

--- a/uniq.js
+++ b/uniq.js
@@ -1,9 +1,9 @@
 module.exports = function(array) {
   var results = [];
 
-  for(var n = array.length - 1; n >= 0; n--) {
+  for(var n = 0; n < array.length; ++n) {
     var item = array[n];
-    if (array.lastIndexOf(item) == n) {
+    if (array.indexOf(item) == n) {
       results.push(item);
     }
   }


### PR DESCRIPTION
I noticed `uniq` is still slightly different from underscore, so I added a comparison test.
